### PR TITLE
Add finder endpoints to customer accounts.

### DIFF
--- a/app/models/customer_account.rb
+++ b/app/models/customer_account.rb
@@ -51,6 +51,18 @@ module FlexCommerce
       nil
     end
 
+    def self.find_by_email(email)
+      requestor.custom("email:#{URI.encode_www_form_component(email)}", {request_method: :get}, {}).first
+    rescue ::FlexCommerceApi::Error::NotFound
+      nil
+    end
+
+    def self.find_by_reference(reference)
+      requestor.custom("reference:#{reference}", {request_method: :get}, {}).first
+    rescue ::FlexCommerceApi::Error::NotFound
+      nil
+    end
+
     def self.generate_token(attributes)
       post_attributes = { reset_link_with_placeholder: attributes[:reset_link_with_placeholder] }
       requestor.custom("email:#{URI.encode_www_form_component(attributes[:email])}/resets", { request_method: :post }, { data: { type: :customer_accounts, attributes: post_attributes } }).first

--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "faker", "~> 1.4"
   spec.add_development_dependency "yard", "~> 0.8"
   spec.add_development_dependency "json-schema", "~> 2.5"
+  spec.add_development_dependency "pry", "~> 0.10.0"
   spec.add_runtime_dependency "oj", "~> 2.12"
 
   spec.add_runtime_dependency "json_api_client", "1.0.2"

--- a/lib/flex/commerce/api/version.rb
+++ b/lib/flex/commerce/api/version.rb
@@ -1,7 +1,7 @@
 module Flex
   module Commerce
     module Api
-      VERSION = "0.1.0"
+      VERSION = "0.3.1"
     end
   end
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
   API_VERSION = "v1"
 end

--- a/spec/integration/customer_account_spec.rb
+++ b/spec/integration/customer_account_spec.rb
@@ -57,6 +57,75 @@ RSpec.describe FlexCommerce::CustomerAccount do
           end
         end
       end
+
+      context "using the email address" do
+        before :each do
+          stub_request(:get, "#{api_root}/customer_accounts/email:#{resource_identifier.attributes.email}.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+        end
+        subject { subject_class.find_by_email(resource_identifier.attributes.email) }
+        it_should_behave_like "a singular resource"
+        it "should return an object with the correct attributes when find is called" do
+          expect(subject.attributes.as_json.reject { |k| %w(id type links meta relationships password).include?(k) }.with_indifferent_access).to eql(resource_identifier.attributes.as_json.with_indifferent_access)
+          expect(subject.type).to eql "customer_accounts"
+        end
+        it "should return nil if an attribute is fetched that is not defined" do
+          expect(subject.undefined_attribute).to be_nil
+        end
+        context "updating an undefined attribute" do
+          let(:patch_headers) { { "Accept" => "application/vnd.api+json", "Content-Type" => "application/vnd.api+json" } }
+          let(:patch_body) do
+            {
+              data: {
+                id: resource_identifier.id.to_s,
+                type: "customer_accounts",
+                attributes: {
+                  my_new_attr: "my new value"
+                }
+              }
+            }
+          end
+          let!(:update_stub) { stub_request(:patch, "#{api_root}/customer_accounts/#{resource_identifier.id}.json_api").with(headers: patch_headers, body: patch_body).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers }
+          it "should set an attribute when an undefined setter is called and then the record is saved" do
+            subject.my_new_attr = "my new value"
+            expect(subject.save).to be_truthy
+          end
+        end
+      end
+
+      context "using the reference" do
+        before :each do
+          stub_request(:get, "#{api_root}/customer_accounts/reference:#{resource_identifier.attributes.reference}.json_api").with(headers: { "Accept" => "application/vnd.api+json" }).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers
+        end
+        subject { subject_class.find_by_reference(resource_identifier.attributes.reference) }
+        it_should_behave_like "a singular resource"
+        it "should return an object with the correct attributes when find is called" do
+          expect(subject.attributes.as_json.reject { |k| %w(id type links meta relationships password).include?(k) }.with_indifferent_access).to eql(resource_identifier.attributes.as_json.with_indifferent_access)
+          expect(subject.type).to eql "customer_accounts"
+        end
+        it "should return nil if an attribute is fetched that is not defined" do
+          expect(subject.undefined_attribute).to be_nil
+        end
+        context "updating an undefined attribute" do
+          let(:patch_headers) { { "Accept" => "application/vnd.api+json", "Content-Type" => "application/vnd.api+json" } }
+          let(:patch_body) do
+            {
+              data: {
+                id: resource_identifier.id.to_s,
+                type: "customer_accounts",
+                attributes: {
+                  my_new_attr: "my new value"
+                }
+              }
+            }
+          end
+          let!(:update_stub) { stub_request(:patch, "#{api_root}/customer_accounts/#{resource_identifier.id}.json_api").with(headers: patch_headers, body: patch_body).to_return body: singular_resource.to_h.to_json, status: response_status, headers: default_headers }
+          it "should set an attribute when an undefined setter is called and then the record is saved" do
+            subject.my_new_attr = "my new value"
+            expect(subject.save).to be_truthy
+          end
+        end
+      end
+
     end
     context "password resetting" do
       let(:account) { build(:customer_account) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "webmock/rspec"
+require "pry"
 # include supporting files from spec/support
 root = File.expand_path("../", __dir__)
 Dir[File.join root, "spec/support/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
This PR adds `find_by_email` and `find_by_reference` methods to the CustomerAccount model in order to identify a customer by their email or reference, respectively. You can call the new methods as follows:

```ruby
FlexCommerce::CustomerAccount.find_by_email('some@email.org')
FlexCommerce::CustomerAccount.find_by_reference('abc123')
```