### PR TITLE
Add support for previewed requests

### DIFF
--- a/flex-commerce-api.gemspec
+++ b/flex-commerce-api.gemspec
@@ -28,8 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", "~> 0.8"
   spec.add_development_dependency "json-schema", "~> 2.5"
   spec.add_development_dependency "pry", "~> 0.10.0"
-  spec.add_runtime_dependency "oj", "~> 2.12"
 
+  spec.add_runtime_dependency "oj", "~> 2.12"
   spec.add_runtime_dependency "json_api_client", "1.0.2"
   spec.add_runtime_dependency "activesupport", "~> 4"
+  spec.add_runtime_dependency "rack", "~> 1.6"
 end

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -8,6 +8,7 @@ require "flex_commerce_api/json_api_client_extension/save_request_body_middlewar
 require "flex_commerce_api/json_api_client_extension/logging_middleware"
 require "flex_commerce_api/json_api_client_extension/status_middleware"
 require "flex_commerce_api/json_api_client_extension/json_format_middleware"
+require "flex_commerce_api/json_api_client_extension/previewed_request_middleware"
 require "flex_commerce_api/json_api_client_extension/has_many_association_proxy"
 require "flex_commerce_api/json_api_client_extension/builder"
 require "flex_commerce_api/json_api_client_extension/flexible_connection"
@@ -63,16 +64,18 @@ module FlexCommerceApi
         super(params)
       end
 
-      def reconfigure_all
+      def reconfigure_all options = {}
         subclasses.each do |sub|
-          sub.reconfigure
+          sub.reconfigure options
         end
-        reconfigure
+        reconfigure options
       end
 
-      def reconfigure
+      def reconfigure options = {}
         self.site = FlexCommerceApi.config.api_base_url
-        self.connection_options = connection_options.merge adapter: FlexCommerceApi.config.adapter || :net_http
+        adapter_options = { adapter: FlexCommerceApi.config.adapter || :net_http }
+        self.connection_options.delete(:include_previewed)
+        self.connection_options = connection_options.merge(adapter_options).merge(options)
         reload_connection_if_required
       end
 

--- a/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/flexible_connection.rb
@@ -5,11 +5,13 @@ module FlexCommerceApi
       def initialize(options = {})
         site = options.fetch(:site)
         adapter_options = Array(options.fetch(:adapter, Faraday.default_adapter))
+        include_previewed = options.fetch :include_previewed, false
         @faraday = Faraday.new(site) do |builder|
           builder.request :json
           builder.use JsonApiClientExtension::SaveRequestBodyMiddleware
           builder.use JsonApiClientExtension::LoggingMiddleware unless FlexCommerceApi.logger.nil?
           builder.use JsonApiClientExtension::JsonFormatMiddleware
+          builder.use JsonApiClientExtension::PreviewedRequestMiddleware if include_previewed
           builder.use JsonApiClient::Middleware::JsonRequest
           builder.use JsonApiClientExtension::StatusMiddleware
           builder.use JsonApiClient::Middleware::ParseJson
@@ -28,5 +30,3 @@ module FlexCommerceApi
     end
   end
 end
-
-

--- a/lib/flex_commerce_api/json_api_client_extension/previewed_request_middleware.rb
+++ b/lib/flex_commerce_api/json_api_client_extension/previewed_request_middleware.rb
@@ -1,0 +1,17 @@
+require "rack/utils"
+
+# Adds preview param to all requests to Flex API.
+module FlexCommerceApi
+  module JsonApiClientExtension
+    class PreviewedRequestMiddleware < ::Faraday::Middleware
+      def call(env)
+        env.url.tap do |url|
+          parsed_query = Rack::Utils.parse_nested_query url.query
+          parsed_query[:preview] = true
+          url.query = parsed_query.to_param
+        end
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
- Adds a new middleware `PreviewedRequestMiddleware` that adds `preview=true` params to all requests.
- Adds a way to configure `Faraday` to include provided middleware.