### PR TITLE
Correct marked-down prices

### DIFF
--- a/app/models/markdown_price.rb
+++ b/app/models/markdown_price.rb
@@ -1,0 +1,11 @@
+require "flex_commerce_api/api_base"
+
+module FlexCommerce
+  class MarkdownPrice < FlexCommerceApi::ApiBase
+    has_one :variant
+
+    def active?
+      Time.now.between?(start_at, end_at)
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -82,5 +82,13 @@ module FlexCommerce
         end
       end
     end
+
+    def current_max_price
+      variants.map(&:current_price).max
+    end
+
+    def current_min_price
+      variants.map(&:current_price).min
+    end
   end
 end

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -10,5 +10,14 @@ module FlexCommerce
   class Variant < FlexCommerceApi::ApiBase
     has_one :product
     has_many :asset_files
+    has_many :markdown_prices
+
+    def current_price
+      if markdown = markdown_prices.find(&:active?)
+        markdown.price
+      else
+        price
+      end
+    end
   end
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.18"
+  VERSION = "0.3.19"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
- [x] Added `MarkdownPrice` model with `active?` method that uses the current time to calculate if applicable or not
- [x] Added `Variant#current_price` to override the attribute from the API response and look through active markdown prices
- [x] Added `Product#current_max_price` and `Product#current_min_price` which loop through the `Variant#current_price` attributes to calculate.