### PR TITLE
Feature/template related resources retrieval

### DIFF
--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -111,7 +111,7 @@ module FlexCommerceApi
 
     def template_attribute(key)
       case attributes[:template_attributes][key][:data_type]
-      when "related-files", "related-products" then self.send(key)
+      when "related-files", "related-products" then (self.send(key) || self.send("template_#{key}"))
       else attributes[:template_attributes][key][:value] rescue nil
       end
     end

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -110,7 +110,10 @@ module FlexCommerceApi
     end
 
     def template_attribute(key)
-      attributes[:template_attributes][key][:value] rescue nil
+      case attributes[:template_attributes][key][:data_type]
+      when "related-files", "related-products" then (self.send(key) || self.send("template_#{key}"))
+      else attributes[:template_attributes][key][:value] rescue nil
+      end
     end
 
     def method_missing(method, *args)

--- a/lib/flex_commerce_api/api_base.rb
+++ b/lib/flex_commerce_api/api_base.rb
@@ -111,7 +111,7 @@ module FlexCommerceApi
 
     def template_attribute(key)
       case attributes[:template_attributes][key][:data_type]
-      when "related-files", "related-products" then (self.send(key) || self.send("template_#{key}"))
+      when "related-files", "related-products" then self.send("template_#{key}")
       else attributes[:template_attributes][key][:value] rescue nil
       end
     end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.31"
+  VERSION = "0.3.33"
   API_VERSION = "v1"
 end

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.34"
+  VERSION = "0.3.35"
   API_VERSION = "v1"
 end

--- a/spec/integration/template_attributes_spec.rb
+++ b/spec/integration/template_attributes_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "url encoding on any model" do
       expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
     end
 
-    it 'does not allow get by direct reference to attribute' do
+    it 'does allows get by direct reference to attribute' do
       expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
     end
   end

--- a/spec/integration/template_attributes_spec.rb
+++ b/spec/integration/template_attributes_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe "url encoding on any model" do
     end
   end
    
-  before(:each) do 
+  before(:each) do
     stub_request(:get, /\/template_attributable_classes\/slug:my_slug\.json_api$/).to_return do |req|
       { body: example_data.to_json, headers: default_headers, status: 200 }
     end
   end
 
-  context 'with template data' do
+  context 'with template data of type text' do
     let!(:example_data) do
       { 
         data: {
@@ -40,6 +40,49 @@ RSpec.describe "url encoding on any model" do
 
     it 'does not allow get by direct reference to attribute' do
       expect(result.foo).to eq nil
+    end
+  end
+
+  context 'with template data of type related-products' do
+    let!(:example_data) do
+      { 
+        data: {
+          id: "1", 
+          type: "template_attributable_class", 
+          attributes: {
+            template_attributes: { template_related_products: { value: [1], data_type: "related-products" } }
+          },
+          relationships: {
+            template_related_products: {
+              data: [
+                {
+                  id: "1",
+                  type: "template_attributable_class"
+                }
+              ]
+            }
+          }
+        },
+        included: [
+          {
+            id: "1",
+            type: "template_attributable_class",
+            attributes: {
+              name: "Product image 1"
+            }
+          }
+        ]
+      }
+    end
+   
+    let(:result) { subject_class.find("slug:my_slug") }
+
+    it 'allows get by template attribute method' do
+      expect(result.template_attribute(:template_related_products).map(&:id)).to eq ["1"]
+    end
+
+    it 'does not allow get by direct reference to attribute' do
+      expect(result.template_related_files).to eq nil
     end
   end
 end

--- a/spec/integration/template_attributes_spec.rb
+++ b/spec/integration/template_attributes_spec.rb
@@ -81,8 +81,51 @@ RSpec.describe "url encoding on any model" do
       expect(result.template_attribute(:template_related_products).map(&:id)).to eq ["1"]
     end
 
+    it 'does allows get by direct reference to attribute' do
+      expect(result.template_attribute(:template_related_products).map(&:id)).to eq ["1"]
+    end
+  end
+
+  context 'with template data of type related-files' do
+    let!(:example_data) do
+      {
+        data: {
+          id: "1",
+          type: "template_attributable_class",
+          attributes: {
+              template_attributes: { template_related_files: { value: [1], data_type: "related-files" } }
+          },
+          relationships: {
+            template_related_files: {
+              data: [
+                {
+                  id: "1",
+                  type: "template_attributable_class"
+                }
+              ]
+            }
+          }
+        },
+        included: [
+          {
+            id: "1",
+            type: "template_attributable_class",
+            attributes: {
+                name: "asset file 1"
+            }
+          }
+        ]
+      }
+    end
+
+    let(:result) { subject_class.find("slug:my_slug") }
+
+    it 'allows get by template attribute method' do
+      expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
+    end
+
     it 'does not allow get by direct reference to attribute' do
-      expect(result.template_related_files).to eq nil
+      expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
     end
   end
 end

--- a/spec/integration/template_attributes_spec.rb
+++ b/spec/integration/template_attributes_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "url encoding on any model" do
           id: "1", 
           type: "template_attributable_class", 
           attributes: {
-            template_attributes: { template_related_products: { value: [1], data_type: "related-products" } }
+            template_attributes: { related_products: { value: [1], data_type: "related-products" } }
           },
           relationships: {
             template_related_products: {
@@ -78,11 +78,11 @@ RSpec.describe "url encoding on any model" do
     let(:result) { subject_class.find("slug:my_slug") }
 
     it 'allows get by template attribute method' do
-      expect(result.template_attribute(:template_related_products).map(&:id)).to eq ["1"]
+      expect(result.template_attribute(:related_products).map(&:id)).to eq ["1"]
     end
 
     it 'does allows get by direct reference to attribute' do
-      expect(result.template_attribute(:template_related_products).map(&:id)).to eq ["1"]
+      expect(result.template_attribute(:related_products).map(&:id)).to eq ["1"]
     end
   end
 
@@ -93,7 +93,7 @@ RSpec.describe "url encoding on any model" do
           id: "1",
           type: "template_attributable_class",
           attributes: {
-              template_attributes: { template_related_files: { value: [1], data_type: "related-files" } }
+              template_attributes: { related_files: { value: [1], data_type: "related-files" } }
           },
           relationships: {
             template_related_files: {
@@ -121,11 +121,11 @@ RSpec.describe "url encoding on any model" do
     let(:result) { subject_class.find("slug:my_slug") }
 
     it 'allows get by template attribute method' do
-      expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
+      expect(result.template_attribute(:related_files).map(&:id)).to eq ["1"]
     end
 
     it 'does allows get by direct reference to attribute' do
-      expect(result.template_attribute(:template_related_files).map(&:id)).to eq ["1"]
+      expect(result.template_attribute(:related_files).map(&:id)).to eq ["1"]
     end
   end
 end


### PR DESCRIPTION
PR adds the ability to retrieve  related resources contained within `template_attributes`, eg.

******

```ruby
resource = ::FlexCommerce::StaticPage.find(1)
resource.template_attribute(:related_files) => [#<FlexCommerce::AssetFile:@attributes={"id"=>"3", "type"=>"asset_files", "name"=>"asset file name-3", "reference"=>"970960163-6-172243000", "asset_file"=>"asset_file.png", "file_content_content_type"=>"image/png", "file_content_filename"=>"asset_file.png", "file_content_size"=>484, "image_height"=>20, "image_width"=>20, "s3_url"=>"https://flexplatform-test.s3.amazonaws.com//Users/mufudzimasaire/rails-projects/flex-platform/public/uploads/asset_file/asset_file/3/asset_file.png", "created_at"=>"2016-04-18T18:00:19Z", "updated_at"=>"2016-04-18T18:00:19Z"}>]
``` 

*******