### PR TITLE
Remove custom order methods

### DIFF
--- a/app/models/customer_account.rb
+++ b/app/models/customer_account.rb
@@ -38,7 +38,6 @@ module FlexCommerce
 
     has_one :cart, class_name: "::FlexCommerce::Cart"
     has_many :addresses, class_name: "::FlexCommerce::Address"
-    has_many :orders, class_name: "::FlexCommerce::Order"
 
     property :email, type: :string
     property :reference, type: :string
@@ -71,6 +70,10 @@ module FlexCommerce
     def self.reset_password(attributes)
       patch_attributes = { password: attributes[:password] }
       requestor.custom("email:#{URI.encode_www_form_component(attributes[:email])}/resets/token:#{attributes[:reset_password_token]}", { request_method: :patch }, { data: { type: :customer_accounts, attributes: patch_attributes } }).first
+    end
+
+    def orders
+      ::FlexCommerce::Order.where(customer_account_id: id)
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -14,12 +14,12 @@ module FlexCommerce
     has_one :shipping_address, class_name: "::FlexCommerce::Address"
     has_one :billing_address, class_name: "::FlexCommerce::Address"
 
-    def self.find_by_customer_account_id(order_id, customer_account_id)
-      requestor.send(:request, :get, "customer_accounts/%d/orders/%d" % [customer_account_id, order_id], {})
-    end
-
-    def self.all_by_customer_account_id(customer_account_id)
-      requestor.send(:request, :get, "customer_accounts/%d/orders" % customer_account_id, {})
+    def self.path(params = nil, record = nil)
+      if params && params[:filter] && (customer_id = params[:filter].delete(:customer_account_id))
+        File.join("customer_accounts/%d" % customer_id, super)
+      else
+        super
+      end
     end
 
     def self.create(attributes)

--- a/lib/flex_commerce_api/version.rb
+++ b/lib/flex_commerce_api/version.rb
@@ -1,4 +1,4 @@
 module FlexCommerceApi
-  VERSION = "0.3.35"
+  VERSION = "0.3.36"
   API_VERSION = "v1"
 end


### PR DESCRIPTION
This PR removes the custom order methods introduced with v0.3.34.

To get customer orders you can now use:

```ruby
# for the history of orders
FlexCommerce::CustomerAccount.find(123).orders
FlexCommerce::Order.where(customer_account_id: 123)

# for a specific order
FlexCommerce::Order.where(customer_account_id: 123).find(456)
```